### PR TITLE
fix SHFIT_ filename bug

### DIFF
--- a/gtrans/data_process/utils.py
+++ b/gtrans/data_process/utils.py
@@ -76,8 +76,8 @@ def get_source(sample_name, buggy=True):
     babel_suffix = suffix + "_babel.js"
 
     for raw_src in cmd_args.raw_srcs:
-        b_src1 = os.path.join(raw_src, sample_name.replace("_SHIFT","") + suffix + ".js")
-        b_src2 = os.path.join(raw_src, sample_name.replace("_SHIFT","") + babel_suffix)
+        b_src1 = os.path.join(raw_src, sample_name.replace("SHIFT_","") + suffix + ".js")
+        b_src2 = os.path.join(raw_src, sample_name.replace("SHIFT_","") + babel_suffix)
         b_src3 = os.path.join(raw_src, sample_name + suffix + ".js")
 
         if not os.path.exists(b_src1) and not os.path.exists(b_src2) and not os.path.exists(b_src3):


### PR DESCRIPTION
Filenames in the cooked dataset after running _run_build_dataset.sh_ is **SHFIT_xxx_buggy.pkl(e.g. SHIFT_01-01-2019/00_6_0selectors_buggy.pkl)**. Therefore it should be sample_name.replace("_SHIFT","")